### PR TITLE
Feature/1 update project structure to redmine 4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Add direct project fields (#1)
+   - Homepage
+   - IsPublic
+   - InheritMembers
+
+### Removed
+- Remove indirect project field CustomFields (#1)
+
+### Fixed
+- Project and Issue create, update, delete accept now additional positive HTTP codes HTTP 201 and HTTP 204

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Intefaces to redmine.
 
 ## APIs
 
-Provide Interfaces to redmine APIs.
+Provide interfaces to Redmine JSON API (Redmine version 4.1).
 
 |API                |Implements|
 |-------------------|---------:|

--- a/client.go
+++ b/client.go
@@ -60,10 +60,10 @@ func (c *Client) URLWithFilter(path string, f Filter) (string, error) {
 func (c *Client) getPaginationClause() string {
 	clause := ""
 	if c.Limit > -1 {
-		clause = clause + fmt.Sprintf("&limit=%v", c.Limit)
+		clause = clause + fmt.Sprintf("&limit=%d", c.Limit)
 	}
 	if c.Offset > -1 {
-		clause = clause + fmt.Sprintf("&offset=%v", c.Offset)
+		clause = clause + fmt.Sprintf("&offset=%d", c.Offset)
 	}
 	return clause
 }

--- a/client.go
+++ b/client.go
@@ -11,16 +11,22 @@ import (
 type Client struct {
 	endpoint string
 	apikey   string
+	Limit    int
+	Offset   int
 	*http.Client
-	Limit  int
-	Offset int
 }
 
 var DefaultLimit int = -1  // "-1" means "No setting"
 var DefaultOffset int = -1 //"-1" means "No setting"
 
 func NewClient(endpoint, apikey string) *Client {
-	return &Client{endpoint, apikey, http.DefaultClient, DefaultLimit, DefaultOffset}
+	return &Client{
+		endpoint: endpoint,
+		apikey:   apikey,
+		Limit:    DefaultLimit,
+		Offset:   DefaultOffset,
+		Client:   http.DefaultClient,
+	}
 }
 
 func (c *Client) apiKeyParameter() string {

--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 )
 
 type Client struct {
@@ -20,6 +21,21 @@ var DefaultOffset int = -1 //"-1" means "No setting"
 
 func NewClient(endpoint, apikey string) *Client {
 	return &Client{endpoint, apikey, http.DefaultClient, DefaultLimit, DefaultOffset}
+}
+
+func (c *Client) apiKeyParameter() string {
+	return "key=" + c.apikey
+}
+
+func (c *Client) concatParameters(requestParameters ...string) string {
+	cleanedParams := []string{}
+	for _, param := range requestParameters {
+		if param != "" {
+			cleanedParams = append(cleanedParams, param)
+		}
+	}
+
+	return strings.Join(cleanedParams, "&")
 }
 
 // URLWithFilter return string url by concat endpoint, path and filter

--- a/client.go
+++ b/client.go
@@ -39,7 +39,7 @@ func (c *Client) concatParameters(requestParameters ...string) string {
 }
 
 // URLWithFilter return string url by concat endpoint, path and filter
-// err != nil when endpoin can not parse
+// err != nil when endpoint can not parse
 func (c *Client) URLWithFilter(path string, f Filter) (string, error) {
 	var fullURL *url.URL
 	fullURL, err := url.Parse(c.endpoint)

--- a/client.go
+++ b/client.go
@@ -16,8 +16,10 @@ type Client struct {
 	*http.Client
 }
 
-var DefaultLimit int = -1  // "-1" means "No setting"
-var DefaultOffset int = -1 //"-1" means "No setting"
+const NoSetting = -1
+
+var DefaultLimit int = NoSetting
+var DefaultOffset int = NoSetting
 
 func NewClient(endpoint, apikey string) *Client {
 	return &Client{

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,42 @@
+package redmine
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestClient_concatParameters(t *testing.T) {
+	type args struct {
+		requestParameters []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"should return empty string for zero parameters", args{}, ""},
+		{"should return same string for one parameters", args{[]string{"key=value"}}, "key=value"},
+		{"should return &-delimited string for two parameters", args{[]string{"key=value", "hello=world"}},
+			"key=value&hello=world"},
+		{"should remove empty parameter at the start and return two parameters", args{[]string{"", "key=value", "hello=world"}},
+			"key=value&hello=world"},
+		{"should remove empty parameter in the middle and return two parameters", args{[]string{"key=value", "", "hello=world"}},
+			"key=value&hello=world"},
+		{"should remove empty parameter in the end and return two parameters", args{[]string{"key=value", "hello=world", ""}},
+			"key=value&hello=world"},
+		{"should remove multiple empty parameter at the start and return two parameters", args{[]string{"", "", "key=value", "hello=world"}},
+			"key=value&hello=world"},
+		{"should remove multiple empty parameter in the middle and return two parameters", args{[]string{"key=value", "", "", "hello=world"}},
+			"key=value&hello=world"},
+		{"should remove multiple empty parameter in the end and return two parameters", args{[]string{"key=value", "hello=world", "", ""}},
+			"key=value&hello=world"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{}
+			if got := c.concatParameters(tt.args.requestParameters...); got != tt.want {
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/cmd/godmine/main.go
+++ b/cmd/godmine/main.go
@@ -445,7 +445,7 @@ UpdatedOn: %s
 
 %s
 `[1:],
-		project.Id,
+		project.ID,
 		project.Name,
 		project.Identifier,
 		project.CreatedOn,
@@ -460,7 +460,7 @@ func listProjects() {
 		fatal("Failed to list projects: %s\n", err)
 	}
 	for _, i := range issues {
-		fmt.Printf("%4d: %s\n", i.Id, i.Name)
+		fmt.Printf("%4d: %s\n", i.ID, i.Name)
 	}
 }
 

--- a/cmd/godmine/main.go
+++ b/cmd/godmine/main.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mattn/go-redmine"
+	"github.com/cloudogu/go-redmine"
 )
 
 const name = "godmine"
@@ -445,7 +445,7 @@ UpdatedOn: %s
 
 %s
 `[1:],
-		project.ID,
+		project.Id,
 		project.Name,
 		project.Identifier,
 		project.CreatedOn,
@@ -460,7 +460,7 @@ func listProjects() {
 		fatal("Failed to list projects: %s\n", err)
 	}
 	for _, i := range issues {
-		fmt.Printf("%4d: %s\n", i.ID, i.Name)
+		fmt.Printf("%4d: %s\n", i.Id, i.Name)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mattn/go-redmine
+module github.com/cloudogu/go-redmine
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/mattn/go-redmine
 
 go 1.13
+
+require github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/issue.go
+++ b/issue.go
@@ -221,7 +221,7 @@ func (c *Client) DeleteIssue(id int) error {
 	}
 
 	decoder := json.NewDecoder(res.Body)
-	if !isHTTPStatusSuccessful(res.StatusCode, []int{http.StatusOK}) {
+	if !isHTTPStatusSuccessful(res.StatusCode, []int{http.StatusOK, http.StatusNoContent}) {
 		var er errorsResult
 		err = decoder.Decode(&er)
 		if err == nil {

--- a/issue.go
+++ b/issue.go
@@ -188,7 +188,7 @@ func (c *Client) UpdateIssue(issue Issue) error {
 	defer res.Body.Close()
 
 	if res.StatusCode == http.StatusNotFound {
-		return errors.New("Not Found")
+		return fmt.Errorf("could not update issue (id: %d) because it was not found", issue.Id)
 	}
 	if !isHTTPStatusSuccessful(res.StatusCode, []int{http.StatusOK, http.StatusNoContent}) {
 		decoder := json.NewDecoder(res.Body)
@@ -217,7 +217,7 @@ func (c *Client) DeleteIssue(id int) error {
 	defer res.Body.Close()
 
 	if res.StatusCode == http.StatusNotFound {
-		return errors.New("Not Found")
+		return fmt.Errorf("could not delete issue (id: %d) because it was not found", id)
 	}
 
 	decoder := json.NewDecoder(res.Body)
@@ -319,8 +319,8 @@ func getOneIssue(c *Client, id int, args map[string]string) (*Issue, error) {
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode == 404 {
-		return nil, errors.New("Not Found")
+	if res.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("issue (id: %d) was not found", id)
 	}
 
 	decoder := json.NewDecoder(res.Body)

--- a/issue.go
+++ b/issue.go
@@ -154,7 +154,7 @@ func (c *Client) CreateIssue(issue Issue) (*Issue, error) {
 
 	decoder := json.NewDecoder(res.Body)
 	var r issueRequest
-	if res.StatusCode != 201 {
+	if !isHTTPStatusSuccessful(res.StatusCode, []int{http.StatusCreated}) {
 		var er errorsResult
 		err = decoder.Decode(&er)
 		if err == nil {
@@ -187,10 +187,10 @@ func (c *Client) UpdateIssue(issue Issue) error {
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode == 404 {
+	if res.StatusCode == http.StatusNotFound {
 		return errors.New("Not Found")
 	}
-	if res.StatusCode != 200 {
+	if !isHTTPStatusSuccessful(res.StatusCode, []int{http.StatusOK, http.StatusNoContent}) {
 		decoder := json.NewDecoder(res.Body)
 		var er errorsResult
 		err = decoder.Decode(&er)
@@ -216,12 +216,12 @@ func (c *Client) DeleteIssue(id int) error {
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode == 404 {
+	if res.StatusCode == http.StatusNotFound {
 		return errors.New("Not Found")
 	}
 
 	decoder := json.NewDecoder(res.Body)
-	if res.StatusCode != 200 {
+	if !isHTTPStatusSuccessful(res.StatusCode, []int{http.StatusOK}) {
 		var er errorsResult
 		err = decoder.Decode(&er)
 		if err == nil {

--- a/issue_categories.go
+++ b/issue_categories.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-type issueCategoriesResult struct {
+type IssueCategoriesResult struct {
 	IssueCategories []IssueCategory `json:"issue_categories"`
 	TotalCount      int             `json:"total_count"`
 }
@@ -36,7 +36,7 @@ func (c *Client) IssueCategories(projectId int) ([]IssueCategory, error) {
 	defer res.Body.Close()
 
 	decoder := json.NewDecoder(res.Body)
-	var r issueCategoriesResult
+	var r IssueCategoriesResult
 	if res.StatusCode == 404 {
 		return nil, errors.New("Not Found")
 	}

--- a/issue_categories.go
+++ b/issue_categories.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-type IssueCategoriesResult struct {
+type issueCategoriesResult struct {
 	IssueCategories []IssueCategory `json:"issue_categories"`
 	TotalCount      int             `json:"total_count"`
 }
@@ -36,7 +36,7 @@ func (c *Client) IssueCategories(projectId int) ([]IssueCategory, error) {
 	defer res.Body.Close()
 
 	decoder := json.NewDecoder(res.Body)
-	var r IssueCategoriesResult
+	var r issueCategoriesResult
 	if res.StatusCode == 404 {
 		return nil, errors.New("Not Found")
 	}

--- a/issue_test.go
+++ b/issue_test.go
@@ -1,0 +1,87 @@
+package redmine
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func Test_getOneIssue(t *testing.T) {
+	t.Run("should parse simple issue JSON without additional arguments", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = fmt.Fprintln(w, `{
+  "issue": {
+    "id": 1,
+    "project": {
+      "id": 1,
+      "name": "example project1"
+    },
+    "tracker": {
+      "id": 1,
+      "name": "Bug"
+    },
+    "status": {
+      "id": 1,
+      "name": "New"
+    },
+    "priority": {
+      "id": 2,
+      "name": "Normal"
+    },
+    "author": {
+      "id": 1,
+      "name": "Redmine Admin"
+    },
+    "subject": "Something should be done",
+    "description": "In this ticket an **important task** should be done1!\r\n\r\nGo ahead!\r\n\r\n`+"```bash\\r\\necho -n $PATH\\r\\n```"+`",
+    "start_date": null,
+    "due_date": null,
+    "done_ratio": 0,
+    "is_private": false,
+    "estimated_hours": null,
+    "total_estimated_hours": null,
+    "spent_hours": 0,
+    "total_spent_hours": 0,
+    "created_on": "2021-02-23T14:20:48Z",
+    "updated_on": "2021-02-23T14:39:02Z",
+    "closed_on": null
+  }
+}`)
+		}))
+		defer ts.Close()
+
+		sut := NewClient(ts.URL, "apiKey")
+
+		actual, err := getOneIssue(sut, 1, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, actual.Id)
+		assert.Equal(t, "Something should be done", actual.Subject)
+		assert.Equal(t, "In this ticket an **important task** should be done1!\r\n\r\nGo ahead!\r\n\r\n"+"```bash\r\necho -n $PATH\r\n```", actual.Description)
+		assert.Equal(t, 0, actual.ProjectId)
+		assert.Equal(t, 0, actual.TrackerId)
+		assert.Equal(t, 0, actual.ParentId)
+		assert.Equal(t, 0, actual.StatusId)
+		assert.Equal(t, 0, actual.PriorityId)
+		assert.Equal(t, "2021-02-23T14:20:48Z", actual.CreatedOn)
+		assert.Equal(t, "2021-02-23T14:39:02Z", actual.UpdatedOn)
+		assert.Equal(t, "", actual.StartDate)
+		assert.Equal(t, "", actual.DueDate)
+		assert.Equal(t, "", actual.ClosedOn)
+
+		expectedProject := IdName{Id: 1, Name: "example project1"}
+		assert.Equal(t, expectedProject, *actual.Project)
+		expectedTracker := IdName{Id: 1, Name: "Bug"}
+		assert.Equal(t, expectedTracker, *actual.Tracker)
+		assert.Nil(t, actual.Parent)
+		expectedStatus := IdName{Id: 1, Name: "New"}
+		assert.Equal(t, expectedStatus, *actual.Status)
+		expectedPriority := IdName{Id: 2, Name: "Normal"}
+		assert.Equal(t, expectedPriority, *actual.Priority)
+		expectedAuthor := IdName{Id: 1, Name: "Redmine Admin"}
+		assert.Equal(t, expectedAuthor, *actual.Author)
+	})
+}

--- a/project.go
+++ b/project.go
@@ -3,9 +3,21 @@ package redmine
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
+)
+
+const (
+	// since Redmine 2.6.0
+	ProjectAdditionalFieldTrackers = "trackers"
+	// since Redmine 2.6.0
+	ProjectAdditionalFieldIssueCategories = "issue_categories"
+	// since Redmine 2.6.0
+	ProjectAdditionalFieldEnabledModules = "enabled_modules"
+	// since Redmine 3.4.0
+	ProjectAdditionalFieldTimeEntryActivities = "time_entry_activities"
 )
 
 type projectRequest struct {
@@ -20,19 +32,73 @@ type projectsResult struct {
 	Projects []Project `json:"projects"`
 }
 
+// Project contains a Redmine API project object according Redmine 4.1 REST API.
+//
+// See also: https://www.redmine.org/projects/redmine/wiki/Rest_api
 type Project struct {
-	Id           int            `json:"id"`
-	Parent       IdName         `json:"parent"`
-	Name         string         `json:"name"`
-	Identifier   string         `json:"identifier"`
-	Description  string         `json:"description"`
-	CreatedOn    string         `json:"created_on"`
-	UpdatedOn    string         `json:"updated_on"`
-	CustomFields []*CustomField `json:"custom_fields,omitempty"`
+	// Id uniquely identifies a project on technical level. This value will be generated on project creation and cannot
+	// be changed. Id is mandatory for all project API calls except CreateProject()
+	Id int `json:"id"`
+	// ParentID may contain the Id of a parent project. If set, this project is then a child project of the parent project.
+	// Projects can be unlimitedly nested.
+	ParentID Id `json:"parent_id"`
+	// Name contains a human readable project name.
+	Name string `json:"name"`
+	// Identifier used by the application for various things (eg. in URLs). It must be unique and cannot be composed of
+	// only numbers. It must contain 1 to 100 characters of which only consist of lowercase latin characters, numbers,
+	// hyphen (-) and underscore (_). Once the project is created, this identifier cannot be modified
+	Identifier string `json:"identifier"`
+	// Description contains a human readable project multiline description that appears on the project overview.
+	Description string `json:"description"`
+	// Homepage contains a URL to a project's website that appears on the project overview.
+	Homepage string `json:"homepage"`
+	// IsPublic controls who can view the project. If set to true the project can be viewed by all the users, including
+	// those who are not members of the project. If set to false, only the project members have access to it, according to
+	// their role.
+	//
+	// since Redmine 2.6.0
+	IsPublic bool `json:"is_public"`
+	// InheritMembers determines whether this project inherits members from a parent project. If set to true (and being a
+	// nested project) all members from the parent project will apply also to this project.
+	InheritMembers bool `json:"inherit_members"`
+	// TrackerIDs
+	// since Redmine 2.6.0
+	TrackerIDs []int `json:"tracker_ids"`
+	// EnabledModuleNames
+	// since Redmine 2.6.0
+	EnabledModuleNames []string `json:"enabled_module_names"`
+	// IssueCategories
+	// since Redmine 2.6.0
+	IssueCategories issueCategoriesResult `json:"issue_categories"`
+	// CustomFields.
+	// the Redmine API description is unclear about this field: Docu mentions issue_custom_field_ids only for
+	// project creation.
+	CustomFields []*CustomField `json:"issue_custom_field_ids,omitempty"`
+	// CreatedOn contains a timestamp of when the project was created.
+	CreatedOn string `json:"created_on"`
+	// UpdatedOn contains the timestamp of when the project was last updated.
+	UpdatedOn string `json:"updated_on"`
 }
 
+// Project returns a single project without additional fields.
 func (c *Client) Project(id int) (*Project, error) {
-	res, err := c.Get(c.endpoint + "/projects/" + strconv.Itoa(id) + ".json?key=" + c.apikey)
+	return c.ProjectWithAdditionalFields(id)
+}
+
+// ProjectWithAdditionalFields returns a single project along with additional fields selected by the caller. The given
+// additional fields can be nil, empty or a set of the currently supported additional project fields.
+//
+// Example to include trackers:
+//  project, err := client.ProjectWithAdditionalFields(42, redmine, ProjectAdditionalFieldTrackers, ProjectAdditionalFieldEnabledModules)
+func (c *Client) ProjectWithAdditionalFields(id int, additionalFields ...string) (*Project, error) {
+	err := validateAdditionalFields(additionalFields...)
+	if err != nil {
+		return nil, err
+	}
+	additionalFieldsParameter := additionalFieldsParam(additionalFieldsParam())
+	parameters := c.concatParameters(c.apiKeyParameter(), additionalFieldsParameter)
+
+	res, err := c.Get(c.endpoint + "/projects/" + strconv.Itoa(id) + ".json?" + parameters)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +106,7 @@ func (c *Client) Project(id int) (*Project, error) {
 
 	decoder := json.NewDecoder(res.Body)
 	var r projectResult
-	if res.StatusCode != 200 {
+	if !isHTTPStatusSuccessful(res.StatusCode, []int{http.StatusOK}) {
 		var er errorsResult
 		err = decoder.Decode(&er)
 		if err == nil {
@@ -55,8 +121,49 @@ func (c *Client) Project(id int) (*Project, error) {
 	return &r.Project, nil
 }
 
+// validateAdditionalFields checks for invalid field names. Repeated fields will be ignored because Redmine handles
+// multiple instances of the same field without error.
+func validateAdditionalFields(additionalFields ...string) error {
+	for _, field := range additionalFields {
+		if field == ProjectAdditionalFieldTrackers ||
+			field == ProjectAdditionalFieldIssueCategories ||
+			field == ProjectAdditionalFieldEnabledModules ||
+			field == ProjectAdditionalFieldTimeEntryActivities {
+			continue
+		}
+		return fmt.Errorf("unsupported additional project field %s found", field)
+	}
+
+	return nil
+}
+
+func additionalFieldsParam(additionalFields ...string) string {
+	return strings.Join(additionalFields, ",")
+}
+
+func isHTTPStatusSuccessful(httpStatus int, acceptedStatuses []int) bool {
+	for _, acceptedStatus := range acceptedStatuses {
+		if httpStatus == acceptedStatus {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (c *Client) Projects() ([]Project, error) {
-	res, err := c.Get(c.endpoint + "/projects.json?key=" + c.apikey + c.getPaginationClause())
+	return c.ProjectsWithAdditionalFields()
+}
+
+func (c *Client) ProjectsWithAdditionalFields(additionalFields ...string) ([]Project, error) {
+	err := validateAdditionalFields(additionalFields...)
+	if err != nil {
+		return nil, err
+	}
+	additionalFieldsParameter := additionalFieldsParam(additionalFieldsParam())
+
+	parameters := c.concatParameters(c.apiKeyParameter(), additionalFieldsParameter, c.getPaginationClause())
+	res, err := c.Get(c.endpoint + "/projects.json?" + parameters)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +171,7 @@ func (c *Client) Projects() ([]Project, error) {
 
 	decoder := json.NewDecoder(res.Body)
 	var r projectsResult
-	if res.StatusCode != 200 {
+	if !isHTTPStatusSuccessful(res.StatusCode, []int{http.StatusOK}) {
 		var er errorsResult
 		err = decoder.Decode(&er)
 		if err == nil {
@@ -86,7 +193,9 @@ func (c *Client) CreateProject(project Project) (*Project, error) {
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest("POST", c.endpoint+"/projects.json?key="+c.apikey, strings.NewReader(string(s)))
+
+	parameters := c.concatParameters(c.apiKeyParameter())
+	req, err := http.NewRequest("POST", c.endpoint+"/projects.json?"+parameters, strings.NewReader(string(s)))
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +208,7 @@ func (c *Client) CreateProject(project Project) (*Project, error) {
 
 	decoder := json.NewDecoder(res.Body)
 	var r projectRequest
-	if res.StatusCode != 201 {
+	if !isHTTPStatusSuccessful(res.StatusCode, []int{http.StatusCreated}) {
 		var er errorsResult
 		err = decoder.Decode(&er)
 		if err == nil {
@@ -121,7 +230,9 @@ func (c *Client) UpdateProject(project Project) error {
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest("PUT", c.endpoint+"/projects/"+strconv.Itoa(project.Id)+".json?key="+c.apikey, strings.NewReader(string(s)))
+
+	parameters := c.concatParameters(c.apiKeyParameter())
+	req, err := http.NewRequest("PUT", c.endpoint+"/projects/"+strconv.Itoa(project.Id)+".json?"+parameters, strings.NewReader(string(s)))
 	if err != nil {
 		return err
 	}
@@ -132,10 +243,10 @@ func (c *Client) UpdateProject(project Project) error {
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode == 404 {
-		return errors.New("Not Found")
+	if res.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("could not update project (id %d) because it was not found", project.Id)
 	}
-	if res.StatusCode != 200 {
+	if !isHTTPStatusSuccessful(res.StatusCode, []int{http.StatusOK}) {
 		decoder := json.NewDecoder(res.Body)
 		var er errorsResult
 		err = decoder.Decode(&er)
@@ -150,7 +261,8 @@ func (c *Client) UpdateProject(project Project) error {
 }
 
 func (c *Client) DeleteProject(id int) error {
-	req, err := http.NewRequest("DELETE", c.endpoint+"/projects/"+strconv.Itoa(id)+".json?key="+c.apikey, strings.NewReader(""))
+	parameters := c.concatParameters(c.apiKeyParameter())
+	req, err := http.NewRequest("DELETE", c.endpoint+"/projects/"+strconv.Itoa(id)+".json?"+parameters, strings.NewReader(""))
 	if err != nil {
 		return err
 	}
@@ -161,12 +273,12 @@ func (c *Client) DeleteProject(id int) error {
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode == 404 {
-		return errors.New("Not Found")
+	if res.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("could not delete project (id %d) because it was not found", id)
 	}
 
 	decoder := json.NewDecoder(res.Body)
-	if res.StatusCode != 200 {
+	if !isHTTPStatusSuccessful(res.StatusCode, []int{http.StatusOK}) {
 		var er errorsResult
 		err = decoder.Decode(&er)
 		if err == nil {

--- a/project.go
+++ b/project.go
@@ -219,7 +219,7 @@ func (c *Client) DeleteProject(id int) error {
 	}
 
 	decoder := json.NewDecoder(res.Body)
-	if !isHTTPStatusSuccessful(res.StatusCode, []int{http.StatusOK}) {
+	if !isHTTPStatusSuccessful(res.StatusCode, []int{http.StatusOK, http.StatusNoContent}) {
 		var er errorsResult
 		err = decoder.Decode(&er)
 		if err == nil {

--- a/project.go
+++ b/project.go
@@ -32,6 +32,24 @@ type projectsResult struct {
 	Projects []Project `json:"projects"`
 }
 
+type TrackerResult struct {
+	Tracker []Tracker `json:""`
+}
+
+type Tracker struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+type EnabledModulsResult struct {
+	Tracker []EnabledModul `json:"enabled_modules"`
+}
+
+type EnabledModul struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
 // Project contains a Redmine API project object according Redmine 4.1 REST API.
 //
 // See also: https://www.redmine.org/projects/redmine/wiki/Rest_api
@@ -61,15 +79,17 @@ type Project struct {
 	// InheritMembers determines whether this project inherits members from a parent project. If set to true (and being a
 	// nested project) all members from the parent project will apply also to this project.
 	InheritMembers bool `json:"inherit_members"`
-	// TrackerIDs
+	// Trackers determine which ticket trackers are used for this project.
+	//
 	// since Redmine 2.6.0
-	TrackerIDs []int `json:"tracker_ids"`
-	// EnabledModuleNames
+	Trackers []Tracker `json:"trackers"`
+	// EnabledModules determine the activated modules for this project.
+	//
 	// since Redmine 2.6.0
-	EnabledModuleNames []string `json:"enabled_module_names"`
+	EnabledModules []EnabledModul `json:"enabled_modules"`
 	// IssueCategories
 	// since Redmine 2.6.0
-	IssueCategories IssueCategoriesResult `json:"issue_categories"`
+	IssueCategories []IssueCategory `json:"issue_categories"`
 	// CustomFields.
 	// the Redmine API description is unclear about this field: Docu mentions issue_custom_field_ids only for
 	// project creation.

--- a/project.go
+++ b/project.go
@@ -77,6 +77,9 @@ func (c *Client) Project(id int) (*Project, error) {
 
 	decoder := json.NewDecoder(res.Body)
 	var r projectResult
+	if res.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("project (id: %d) was not found", id)
+	}
 	if !isHTTPStatusSuccessful(res.StatusCode, []int{http.StatusOK}) {
 		var er errorsResult
 		err = decoder.Decode(&er)
@@ -185,7 +188,7 @@ func (c *Client) UpdateProject(project Project) error {
 	defer res.Body.Close()
 
 	if res.StatusCode == http.StatusNotFound {
-		return fmt.Errorf("could not update project (id %d) because it was not found", project.Id)
+		return fmt.Errorf("could not update project (id: %d) because it was not found", project.Id)
 	}
 	if !isHTTPStatusSuccessful(res.StatusCode, []int{http.StatusOK, http.StatusNoContent}) {
 		decoder := json.NewDecoder(res.Body)

--- a/project.go
+++ b/project.go
@@ -69,7 +69,7 @@ type Project struct {
 	EnabledModuleNames []string `json:"enabled_module_names"`
 	// IssueCategories
 	// since Redmine 2.6.0
-	IssueCategories issueCategoriesResult `json:"issue_categories"`
+	IssueCategories IssueCategoriesResult `json:"issue_categories"`
 	// CustomFields.
 	// the Redmine API description is unclear about this field: Docu mentions issue_custom_field_ids only for
 	// project creation.

--- a/project.go
+++ b/project.go
@@ -73,7 +73,7 @@ type Project struct {
 	// CustomFields.
 	// the Redmine API description is unclear about this field: Docu mentions issue_custom_field_ids only for
 	// project creation.
-	CustomFields []*CustomField `json:"issue_custom_field_ids,omitempty"`
+	CustomFields []int `json:"issue_custom_field_ids,omitempty"`
 	// CreatedOn contains a timestamp of when the project was created.
 	CreatedOn string `json:"created_on"`
 	// UpdatedOn contains the timestamp of when the project was last updated.

--- a/project.go
+++ b/project.go
@@ -246,7 +246,7 @@ func (c *Client) UpdateProject(project Project) error {
 	if res.StatusCode == http.StatusNotFound {
 		return fmt.Errorf("could not update project (id %d) because it was not found", project.Id)
 	}
-	if !isHTTPStatusSuccessful(res.StatusCode, []int{http.StatusOK}) {
+	if !isHTTPStatusSuccessful(res.StatusCode, []int{http.StatusOK, http.StatusNoContent}) {
 		decoder := json.NewDecoder(res.Body)
 		var er errorsResult
 		err = decoder.Decode(&er)

--- a/project.go
+++ b/project.go
@@ -9,17 +9,6 @@ import (
 	"strings"
 )
 
-const (
-	// since Redmine 2.6.0
-	ProjectAdditionalFieldTrackers = "trackers"
-	// since Redmine 2.6.0
-	ProjectAdditionalFieldIssueCategories = "issue_categories"
-	// since Redmine 2.6.0
-	ProjectAdditionalFieldEnabledModules = "enabled_modules"
-	// since Redmine 3.4.0
-	ProjectAdditionalFieldTimeEntryActivities = "time_entry_activities"
-)
-
 type projectRequest struct {
 	Project Project `json:"project"`
 }

--- a/project_test.go
+++ b/project_test.go
@@ -1,6 +1,13 @@
 package redmine
 
-import "testing"
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
 
 func Test_validateAdditionalFields(t *testing.T) {
 	type args struct {
@@ -62,4 +69,74 @@ func Test_additionalFieldsParam(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClient_ProjectWithAdditionalFields(t *testing.T) {
+	t.Run("should parse general project fields, module names, and trackers from http response", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = fmt.Fprintln(w, `{
+  "project": {
+    "id": 1,
+    "name": "example project",
+    "identifier": "exampleproject",
+    "description": "This is an example project.",
+    "homepage": "http://github.com/cloudogu/go-redmine",
+    "status": 1,
+    "is_public": true,
+    "inherit_members": true,
+    "trackers": [
+      {
+        "id": 1,
+        "name": "Bug"
+      },
+      {
+        "id": 2,
+        "name": "Feature"
+      }
+    ],
+    "enabled_modules": [
+      {
+        "id": 71,
+        "name": "issue_tracking"
+      },
+			{
+        "id": 73,
+        "name": "wiki"
+      }
+    ],
+    "created_on": "2021-02-19T16:51:03Z",
+    "updated_on": "2021-02-19T16:51:25Z"
+  }
+}`)
+		}))
+		defer ts.Close()
+
+		sut := NewClient(ts.URL, "apiKey")
+
+		actualProject, err := sut.ProjectWithAdditionalFields(1, "enabled_modules", "trackers")
+
+		require.NoError(t, err)
+		require.NotEmpty(t, actualProject)
+		expectedProject := &Project{
+			Id:             1,
+			ParentID:       Id{},
+			Name:           "example project",
+			Identifier:     "exampleproject",
+			Description:    "This is an example project.",
+			Homepage:       "http://github.com/cloudogu/go-redmine",
+			IsPublic:       true,
+			InheritMembers: true,
+			Trackers: []Tracker{
+				{ID: 1, Name: "Bug"},
+				{ID: 2, Name: "Feature"},
+			},
+			EnabledModules: []EnabledModul{
+				{ID: 71, Name: "issue_tracking"},
+				{ID: 73, Name: "wiki"},
+			},
+			CreatedOn: "2021-02-19T16:51:03Z",
+			UpdatedOn: "2021-02-19T16:51:25Z",
+		}
+		assert.Equal(t, expectedProject, actualProject)
+	})
 }

--- a/project_test.go
+++ b/project_test.go
@@ -9,70 +9,8 @@ import (
 	"testing"
 )
 
-func Test_validateAdditionalFields(t *testing.T) {
-	type args struct {
-		fields []string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
-	}{
-		{"should pass for single valid field", args{fields: []string{"trackers"}}, false},
-		{"should pass for multiple valid fields", args{fields: []string{"enabled_modules", "trackers"}}, false},
-		{"should pass for all fields", args{fields: []string{
-			"trackers", "issue_categories", "enabled_modules", "time_entry_activities"}}, false},
-		{"should pass for repeated fields", args{fields: []string{
-			"trackers", "issue_categories", "enabled_modules", "time_entry_activities",
-			"trackers", "issue_categories", "enabled_modules", "time_entry_activities"}}, false},
-		{"should fail for single unsupported field", args{fields: []string{"invalid value"}}, true},
-		{"should fail for single unsupported field among valid fields", args{fields: []string{"enabled_modules", "invalidvalue"}}, true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := validateAdditionalFields(tt.args.fields...); (err != nil) != tt.wantErr {
-				t.Errorf("validateAdditionalFields() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-	t.Run("should pass for non-existing parameter", func(t *testing.T) {
-		if err := validateAdditionalFields(); (err != nil) != false {
-			t.Errorf("expected error for empty string")
-		}
-	})
-	t.Run("should fail for empty string", func(t *testing.T) {
-		if err := validateAdditionalFields(""); (err != nil) != true {
-			t.Errorf("expected error for empty string")
-		}
-	})
-}
-
-func Test_additionalFieldsParam(t *testing.T) {
-	type args struct {
-		additionalFields []string
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{"should create empty string for nil", args{nil}, ""},
-		{"should create empty string for empty slice", args{[]string{}}, ""},
-		{"should create parameter without comma for single field", args{[]string{"enabled_modules"}}, "enabled_modules"},
-		{"should create comma delimited list without trailing comma for multiple fields", args{[]string{
-			"enabled_modules", "enabled_modules", "trackers"}}, "enabled_modules,enabled_modules,trackers"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := additionalFieldsParam(tt.args.additionalFields...); got != tt.want {
-				t.Errorf("additionalFieldsParam() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestClient_ProjectWithAdditionalFields(t *testing.T) {
-	t.Run("should parse general project fields, module names, and trackers from http response", func(t *testing.T) {
+func TestClient_Project(t *testing.T) {
+	t.Run("should parse general project fields, and ignore module names and trackers from http response", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			_, _ = fmt.Fprintln(w, `{
   "project": {
@@ -113,7 +51,7 @@ func TestClient_ProjectWithAdditionalFields(t *testing.T) {
 
 		sut := NewClient(ts.URL, "apiKey")
 
-		actualProject, err := sut.ProjectWithAdditionalFields(1, "enabled_modules", "trackers")
+		actualProject, err := sut.Project(1)
 
 		require.NoError(t, err)
 		require.NotEmpty(t, actualProject)
@@ -126,16 +64,8 @@ func TestClient_ProjectWithAdditionalFields(t *testing.T) {
 			Homepage:       "http://github.com/cloudogu/go-redmine",
 			IsPublic:       true,
 			InheritMembers: true,
-			Trackers: []Tracker{
-				{ID: 1, Name: "Bug"},
-				{ID: 2, Name: "Feature"},
-			},
-			EnabledModules: []EnabledModul{
-				{ID: 71, Name: "issue_tracking"},
-				{ID: 73, Name: "wiki"},
-			},
-			CreatedOn: "2021-02-19T16:51:03Z",
-			UpdatedOn: "2021-02-19T16:51:25Z",
+			CreatedOn:      "2021-02-19T16:51:03Z",
+			UpdatedOn:      "2021-02-19T16:51:25Z",
 		}
 		assert.Equal(t, expectedProject, actualProject)
 	})

--- a/project_test.go
+++ b/project_test.go
@@ -1,0 +1,65 @@
+package redmine
+
+import "testing"
+
+func Test_validateAdditionalFields(t *testing.T) {
+	type args struct {
+		fields []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"should pass for single valid field", args{fields: []string{"trackers"}}, false},
+		{"should pass for multiple valid fields", args{fields: []string{"enabled_modules", "trackers"}}, false},
+		{"should pass for all fields", args{fields: []string{
+			"trackers", "issue_categories", "enabled_modules", "time_entry_activities"}}, false},
+		{"should pass for repeated fields", args{fields: []string{
+			"trackers", "issue_categories", "enabled_modules", "time_entry_activities",
+			"trackers", "issue_categories", "enabled_modules", "time_entry_activities"}}, false},
+		{"should fail for single unsupported field", args{fields: []string{"invalid value"}}, true},
+		{"should fail for single unsupported field among valid fields", args{fields: []string{"enabled_modules", "invalidvalue"}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateAdditionalFields(tt.args.fields...); (err != nil) != tt.wantErr {
+				t.Errorf("validateAdditionalFields() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+	t.Run("should pass for non-existing parameter", func(t *testing.T) {
+		if err := validateAdditionalFields(); (err != nil) != false {
+			t.Errorf("expected error for empty string")
+		}
+	})
+	t.Run("should fail for empty string", func(t *testing.T) {
+		if err := validateAdditionalFields(""); (err != nil) != true {
+			t.Errorf("expected error for empty string")
+		}
+	})
+}
+
+func Test_additionalFieldsParam(t *testing.T) {
+	type args struct {
+		additionalFields []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"should create empty string for nil", args{nil}, ""},
+		{"should create empty string for empty slice", args{[]string{}}, ""},
+		{"should create parameter without comma for single field", args{[]string{"enabled_modules"}}, "enabled_modules"},
+		{"should create comma delimited list without trailing comma for multiple fields", args{[]string{
+			"enabled_modules", "enabled_modules", "trackers"}}, "enabled_modules,enabled_modules,trackers"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := additionalFieldsParam(tt.args.additionalFields...); got != tt.want {
+				t.Errorf("additionalFieldsParam() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
With Redmine 4.1 the original code from mattn/go-redmine did not work out smoothly.

This PR
- adds direct project fields
   - Homepage
   - IsPublic
   - InheritMembers
- removes indirect project field CustomFields, and
- fixes falsely interpreted HTTP 2xx status as error
   - Project and Issue for the actions: create, update, delete